### PR TITLE
docs(widgetbook): normalize fenced code blocks in README to fix markd…

### DIFF
--- a/widgetbook/assets/README_COPIED.md
+++ b/widgetbook/assets/README_COPIED.md
@@ -54,12 +54,12 @@ fpx add input_field
 
 For adding new widgets, place them in lib/ folder. And don't forget to add them to th widgetbook app. Add a wrapper in widgetbook/lib for your new widget.
 After adding a widget, don't forget to trigger the code generation for widgetbook:
-```
+```sh
 cd widgetbook && dart run build_runner build -d
 ```
 
 To see Widgetbook in action:
-```
+```sh
 cd widgetbook && flutter run
 ```
 

--- a/widgetbook/devtools_options.yaml
+++ b/widgetbook/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -752,7 +752,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.14"
+    version: "0.2.0"
   url_launcher:
     dependency: "direct main"
     description:


### PR DESCRIPTION
…own_widget language errors

### What was the issue?
When running Widgetbook, repeated logs appeared:
`get language error: Unexpected null value.`

This came from `markdown_widget` when fenced code blocks (```...```) in the README did not specify a language. As a result, syntax highlighting failed and noisy logs were printed.

### What changed?
- Updated `widgetbook/assets/README_COPIED.md` to explicitly mark code blocks with the correct language(sh).
- Ensured proper syntax highlighting in Widgetbook.
- Verified that no `Unexpected null value` logs appear anymore.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

This PR fixes repeated get language error: Unexpected null value. logs coming from markdown_widget:^2.3.2+8 when rendering the Introduction page in Widgetbook.

Debugging process
 •Used Chrome DevTools → Pause on uncaught/caught exceptions to trace where the error originated.
 •Verified via logs that the error came from fenced code blocks inside README_COPIED.md that had invalid/unsupported language tags.
 •Added temporary logs to inspect what language was being passed down to the PreConfig in markdown_widget.

Explored solutions
1. Fork markdown_widget and patch its CodeBlockNode → too heavy-handed for this case.
2. Patch in initState by sanitizing the readme before passing it to MarkdownWidget.
3. Edit README directly to fix invalid fences.

Final solution

We applied the simplest, most stable fix:
•Edited README_COPIED.md so that all shell commands use a proper ```sh fenced block instead of malformed/empty fences.
•This ensures that the Markdown parser receives a valid, supported language (sh) and prevents null values from reaching the highlighting logic.
•No runtime hacks or unsafe overrides required.

Result
•No more get language error: Unexpected null value. spam in console.
•Introduction README renders correctly with syntax highlighting for shell commands.
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
